### PR TITLE
feat: show all cron jobs and missing data on dashboard

### DIFF
--- a/app/api/module-status/route.ts
+++ b/app/api/module-status/route.ts
@@ -1,21 +1,53 @@
 import { NextResponse } from 'next/server';
 import { createServerClient } from '@/lib/supabase';
 
+// All cron jobs defined in crontab.txt (GMT+8 schedule time for display)
+const CRON_JOBS: { module_name: string; schedule: string }[] = [
+  { module_name: 'strava_token_refresh', schedule: '05:00' },
+  { module_name: 'pelosi_check',         schedule: '06:01' },
+  { module_name: 'strava_sync',          schedule: '08:00' },
+  { module_name: 'strava_daily',         schedule: '08:05' },
+  { module_name: 'ai_funding_news',      schedule: '09:45' },
+  { module_name: 'product_hunt',         schedule: '09:50' },
+  { module_name: 'ai_intelligence',      schedule: '09:55' },
+  { module_name: 'tech_radar',           schedule: '10:00' },
+  { module_name: 'bitcoin_etf_report',   schedule: '10:39' },
+  { module_name: 'alpha_brief',          schedule: '10:42' },
+  { module_name: 'pelosi_tracker',       schedule: '10:45' },
+  { module_name: 'leaps_buy_zone',       schedule: '10:48' },
+  { module_name: 'clawhub_skills',       schedule: '10:49' },
+  { module_name: 'email_summary',        schedule: '10:51' },
+  { module_name: 'iran_war_risk',        schedule: '10:58' },
+];
+
 export async function GET() {
   try {
     const supabase = createServerClient();
 
     const { data, error } = await supabase
       .from('module_status')
-      .select('*')
-      .order('module_name', { ascending: true });
+      .select('*');
 
     if (error) {
       console.error('[module-status] Supabase query error:', error);
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
 
-    return NextResponse.json(data ?? []);
+    const dbMap = new Map((data ?? []).map((row: Record<string, unknown>) => [row.module_name, row]));
+
+    const merged = CRON_JOBS.map(({ module_name, schedule }) => {
+      const db = dbMap.get(module_name) as Record<string, unknown> | undefined;
+      return {
+        id: db?.id ?? module_name,
+        module_name,
+        schedule,
+        status: (db?.last_status as string) ?? 'pending',
+        last_run_at: (db?.last_run_at as string) ?? null,
+        last_message: (db?.last_message as string) ?? null,
+      };
+    });
+
+    return NextResponse.json(merged);
   } catch (err) {
     console.error('[module-status] Unexpected error:', err);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/app/api/reports/route.ts
+++ b/app/api/reports/route.ts
@@ -1,0 +1,49 @@
+import { createServerClient } from '@/lib/supabase'
+import { NextResponse } from 'next/server'
+
+const DEFAULT_LIMIT = 5
+const MAX_LIMIT = 20
+const DEFAULT_DAYS = 7
+const MAX_DAYS = 90
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url)
+
+    const module = searchParams.get('module') || null
+
+    const rawLimit = parseInt(searchParams.get('limit') || String(DEFAULT_LIMIT))
+    const limit = Number.isFinite(rawLimit) && rawLimit > 0 ? Math.min(rawLimit, MAX_LIMIT) : DEFAULT_LIMIT
+
+    const rawDays = parseInt(searchParams.get('days') || String(DEFAULT_DAYS))
+    const days = Number.isFinite(rawDays) && rawDays > 0 ? Math.min(rawDays, MAX_DAYS) : DEFAULT_DAYS
+
+    const since = new Date()
+    since.setDate(since.getDate() - days)
+    const sinceDate = since.toISOString().slice(0, 10)
+
+    const supabase = createServerClient()
+
+    let query = supabase
+      .from('reports')
+      .select('*')
+      .gte('date', sinceDate)
+      .order('date', { ascending: false })
+      .order('created_at', { ascending: false })
+      .limit(limit)
+
+    if (module) query = query.eq('module', module)
+
+    const { data, error } = await query
+
+    if (error) {
+      console.error('[reports]', error)
+      return NextResponse.json({ error: error.message }, { status: 500 })
+    }
+
+    return NextResponse.json(data)
+  } catch (err) {
+    console.error('[reports]', err)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,9 @@ import BitcoinETFCard from '@/components/modules/BitcoinETFCard'
 import AIIntelCard from '@/components/modules/AIIntelCard'
 import StravaCard from '@/components/modules/StravaCard'
 import LeapsCard from '@/components/modules/LeapsCard'
+import AlphaBriefCard from '@/components/modules/AlphaBriefCard'
+import IranRiskCard from '@/components/modules/IranRiskCard'
+import ClawHubCard from '@/components/modules/ClawHubCard'
 import ModuleStatus from '@/components/modules/ModuleStatus'
 
 export default function DashboardPage() {
@@ -37,6 +40,9 @@ export default function DashboardPage() {
           <AIIntelCard />
           <StravaCard />
           <LeapsCard />
+          <AlphaBriefCard />
+          <IranRiskCard />
+          <ClawHubCard />
         </div>
 
         <div className="mt-8 text-center text-gray-600 text-xs">

--- a/components/modules/AIIntelCard.tsx
+++ b/components/modules/AIIntelCard.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react'
 interface AIItem {
   id: number
   date: string
-  source: 'arxiv' | 'huggingface' | 'github'
+  source: string
   title: string
   url: string
   summary: string
@@ -16,12 +16,16 @@ const SOURCE_LABELS: Record<string, string> = {
   arxiv: 'arXiv',
   huggingface: 'HuggingFace',
   github: 'GitHub',
+  funding: 'AI Funding',
+  producthunt: 'Product Hunt',
 }
 
 const SOURCE_COLORS: Record<string, string> = {
   arxiv: 'text-blue-400 bg-blue-400/10',
   huggingface: 'text-yellow-400 bg-yellow-400/10',
   github: 'text-purple-400 bg-purple-400/10',
+  funding: 'text-green-400 bg-green-400/10',
+  producthunt: 'text-orange-400 bg-orange-400/10',
 }
 
 export default function AIIntelCard() {
@@ -40,7 +44,7 @@ export default function AIIntelCard() {
   }, [])
 
   const filtered = activeSource === 'all' ? data : data.filter((d) => d.source === activeSource)
-  const sources = ['all', 'arxiv', 'huggingface', 'github']
+  const sources = ['all', 'arxiv', 'huggingface', 'github', 'funding', 'producthunt']
 
   return (
     <div className="bg-gray-900 border border-gray-800 rounded-xl p-5">

--- a/components/modules/AlphaBriefCard.tsx
+++ b/components/modules/AlphaBriefCard.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface ReportRow {
+  id: number
+  date: string
+  module: string
+  content: string
+  format: string
+  created_at: string
+}
+
+export default function AlphaBriefCard() {
+  const [data, setData] = useState<ReportRow[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetch('/api/reports?module=alpha_brief&limit=5')
+      .then((r) => r.json())
+      .then((d) => {
+        setData(Array.isArray(d) ? d : [])
+        setLoading(false)
+      })
+      .catch(() => setLoading(false))
+  }, [])
+
+  const latest = data[0] ?? null
+
+  return (
+    <div className="bg-gray-900 border border-gray-800 rounded-xl p-5">
+      <div className="flex items-center gap-2 mb-4">
+        <span className="text-2xl">📈</span>
+        <h2 className="text-white font-semibold text-lg">Alpha Brief</h2>
+        {latest && (
+          <span className="ml-auto text-gray-500 text-xs">{latest.date}</span>
+        )}
+      </div>
+
+      {loading ? (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-16 bg-gray-800 rounded-lg animate-pulse" />
+          ))}
+        </div>
+      ) : !latest ? (
+        <div className="text-center py-8 text-gray-500 text-sm">
+          暂无数据，请运行 alpha_brief.py
+        </div>
+      ) : (
+        <div className="max-h-80 overflow-y-auto pr-1">
+          <pre className="text-gray-300 text-xs whitespace-pre-wrap font-sans leading-relaxed">
+            {latest.content}
+          </pre>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/modules/ClawHubCard.tsx
+++ b/components/modules/ClawHubCard.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface ReportRow {
+  id: number
+  date: string
+  module: string
+  content: string
+  format: string
+  created_at: string
+}
+
+export default function ClawHubCard() {
+  const [report, setReport] = useState<ReportRow | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetch('/api/reports?module=clawhub_skills&limit=1')
+      .then((r) => r.json())
+      .then((d) => {
+        const rows = Array.isArray(d) ? d : []
+        setReport(rows.length > 0 ? rows[0] : null)
+        setLoading(false)
+      })
+      .catch(() => setLoading(false))
+  }, [])
+
+  return (
+    <div className="bg-gray-900 border border-gray-800 rounded-xl p-5">
+      <div className="flex items-center gap-2 mb-4">
+        <span className="text-2xl">🦀</span>
+        <h2 className="text-white font-semibold text-lg">ClawHub Skills</h2>
+        {report && (
+          <span className="ml-auto text-gray-500 text-xs">{report.date}</span>
+        )}
+      </div>
+
+      {loading ? (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-16 bg-gray-800 rounded-lg animate-pulse" />
+          ))}
+        </div>
+      ) : !report ? (
+        <div className="text-center py-8 text-gray-500 text-sm">
+          暂无数据，请运行 clawhub_skills.py
+        </div>
+      ) : (
+        <pre className="text-gray-300 text-xs whitespace-pre-wrap font-sans leading-relaxed max-h-80 overflow-y-auto">
+          {report.content}
+        </pre>
+      )}
+    </div>
+  )
+}

--- a/components/modules/IranRiskCard.tsx
+++ b/components/modules/IranRiskCard.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface ReportRow {
+  id: number
+  date: string
+  module: string
+  content: string
+  format: string
+  created_at: string
+}
+
+export default function IranRiskCard() {
+  const [report, setReport] = useState<ReportRow | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetch('/api/reports?module=iran_war_risk&limit=1')
+      .then((r) => r.json())
+      .then((d) => {
+        const rows = Array.isArray(d) ? d : []
+        setReport(rows.length > 0 ? rows[0] : null)
+        setLoading(false)
+      })
+      .catch(() => setLoading(false))
+  }, [])
+
+  return (
+    <div className="bg-gray-900 border border-gray-800 rounded-xl p-5">
+      <div className="flex items-center gap-2 mb-4">
+        <span className="text-2xl">⚠️</span>
+        <h2 className="text-white font-semibold text-lg">伊朗战争风险</h2>
+        {report && (
+          <span className="ml-auto text-gray-500 text-xs">{report.date}</span>
+        )}
+      </div>
+
+      {loading ? (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-16 bg-gray-800 rounded-lg animate-pulse" />
+          ))}
+        </div>
+      ) : !report ? (
+        <div className="text-center py-8 text-gray-500 text-sm">
+          暂无数据，请运行 iran_war_risk.py
+        </div>
+      ) : (
+        <pre className="text-gray-300 text-xs whitespace-pre-wrap font-sans leading-relaxed max-h-80 overflow-y-auto">
+          {report.content}
+        </pre>
+      )}
+    </div>
+  )
+}

--- a/components/modules/ModuleStatus.tsx
+++ b/components/modules/ModuleStatus.tsx
@@ -5,8 +5,10 @@ import { useEffect, useState } from 'react';
 interface ModuleStatusRow {
   id: string;
   module_name: string;
-  status: 'success' | 'error' | string;
+  schedule: string;
+  status: 'success' | 'error' | 'pending' | string;
   last_run_at: string | null;
+  last_message: string | null;
 }
 
 function formatRelativeTime(dateStr: string | null): string {
@@ -19,6 +21,12 @@ function formatRelativeTime(dateStr: string | null): string {
   if (hours < 24) return `${hours}h ago`;
   const days = Math.floor(hours / 24);
   return `${days}d ago`;
+}
+
+function statusDot(status: string) {
+  if (status === 'success') return 'bg-green-500';
+  if (status === 'error') return 'bg-red-500';
+  return 'bg-gray-600';
 }
 
 export default function ModuleStatus() {
@@ -35,29 +43,31 @@ export default function ModuleStatus() {
         setModules(data);
         setLoaded(true);
       })
-      .catch(() => {
-        setLoaded(true);
-      });
+      .catch(() => setLoaded(true));
   }, []);
 
-  if (!loaded || modules.length === 0) return null;
+  if (!loaded) return null;
 
   return (
-    <div className="w-full bg-gray-950 px-4 py-2">
-      <div className="flex gap-2 overflow-x-auto scrollbar-thin scrollbar-thumb-gray-700 scrollbar-track-transparent pb-1">
+    <div className="w-full bg-gray-900 rounded-xl border border-gray-800 px-4 py-3 mb-5">
+      <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+        Cron Jobs
+      </p>
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-2">
         {modules.map((mod) => (
           <div
             key={mod.id}
-            className="flex shrink-0 items-center gap-1.5 rounded-full bg-gray-800 px-3 py-1 text-xs text-gray-300"
+            title={mod.last_message ?? mod.module_name}
+            className="flex items-center gap-1.5 rounded-lg bg-gray-800 px-2.5 py-1.5 text-xs"
           >
             <span
-              className={`h-2 w-2 rounded-full ${
-                mod.status === 'success' ? 'bg-green-500' : 'bg-red-500'
-              }`}
-              aria-label={mod.status === 'success' ? 'success' : 'error'}
+              className={`h-2 w-2 shrink-0 rounded-full ${statusDot(mod.status)}`}
+              aria-label={mod.status}
             />
-            <span className="font-medium text-gray-100">{mod.module_name}</span>
-            <span className="text-gray-500">{formatRelativeTime(mod.last_run_at)}</span>
+            <div className="min-w-0">
+              <p className="truncate font-medium text-gray-100">{mod.module_name}</p>
+              <p className="text-gray-500">{mod.schedule} · {formatRelativeTime(mod.last_run_at)}</p>
+            </div>
           </div>
         ))}
       </div>

--- a/scripts/strava_sync.py
+++ b/scripts/strava_sync.py
@@ -73,7 +73,7 @@ def _supabase_headers() -> dict[str, str]:
 
 
 def _supabase_base_url() -> str:
-    url = os.environ.get("SUPABASE_URL", "")
+    url = os.environ.get("SUPABASE_URL") or os.environ.get("NEXT_PUBLIC_SUPABASE_URL", "")
     if not url:
         raise EnvironmentError("SUPABASE_URL is not set")
     return url.rstrip("/")
@@ -108,7 +108,7 @@ def update_module_status(module_name: str, status: str, message: str) -> None:
 
     status must be 'success' or 'error' (enforced by the DB CHECK constraint).
     """
-    now = datetime.datetime.now(timezone.utc).isoformat() + "Z"
+    now = datetime.datetime.now(datetime.timezone.utc).isoformat() + "Z"
     row = {
         "module_name": module_name,
         "last_run_at": now,

--- a/scripts/strava_token_refresh.py
+++ b/scripts/strava_token_refresh.py
@@ -24,6 +24,8 @@ from pathlib import Path
 import requests
 from dotenv import load_dotenv, set_key
 
+from common import update_module_status
+
 # ---------------------------------------------------------------------------
 # Bootstrap
 # ---------------------------------------------------------------------------
@@ -146,17 +148,21 @@ def main() -> None:
         token_data = refresh_access_token()
         persist_tokens(token_data)
         log.info("=== Token refresh complete ===")
+        update_module_status("strava_token_refresh", "success", "Strava tokens refreshed successfully")
 
     except EnvironmentError as exc:
         log.error("Configuration error: %s", exc)
+        update_module_status("strava_token_refresh", "error", str(exc))
         sys.exit(1)
 
     except requests.RequestException as exc:
         log.error("Network error while contacting Strava: %s", exc)
+        update_module_status("strava_token_refresh", "error", str(exc))
         sys.exit(1)
 
     except (RuntimeError, ValueError) as exc:
         log.error("Token refresh failed: %s", exc)
+        update_module_status("strava_token_refresh", "error", str(exc))
         sys.exit(1)
 
 


### PR DESCRIPTION
## Summary

- **ModuleStatus**: 重构为网格布局，展示全部 15 个 cron job（静态列表与 DB merge，未运行的显示 pending）
- **AIIntelCard**: 新增 AI Funding 和 Product Hunt 两个 source tab
- **新卡片**: AlphaBriefCard、IranRiskCard、ClawHubCard（读取 `reports` 表）
- **新 API**: `/api/reports` 支持 `module`/`limit`/`days` 过滤
- **strava_token_refresh**: 补充 `update_module_status()` 调用

## Test plan

- [ ] Dashboard 显示 7 张卡片（BitcoinETF, AIIntel, Strava, Leaps, AlphaBrief, IranRisk, ClawHub）
- [ ] ModuleStatus 网格展示全部 15 个 cron job
- [ ] AIIntelCard 有 AI Funding 和 Product Hunt tabs
- [ ] `/api/reports?module=alpha_brief` 返回正确数据
- [ ] strava_token_refresh 运行后更新 module_status 表

🤖 Generated with [Claude Code](https://claude.com/claude-code)